### PR TITLE
feat: move common functionalities to show package

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,7 @@ name: Go
 
 on:
   push:
-    branches: [ main ]
+    branches: [ '*' ]
   pull_request:
     branches: [ main ]
 
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.13
+        go-version: ^1.15
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -24,13 +24,9 @@ jobs:
     - name: Get dependencies
       run: |
         go get -v -t -d ./...
-        if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-        fi
 
     - name: Build
       run: go build -v .
 
     - name: Test
-      run: go test -v .
+      run: go test -v ./...

--- a/internal/copy/copy.go
+++ b/internal/copy/copy.go
@@ -1,0 +1,134 @@
+/* MIT License
+ *
+ * Copyright (c) 2017 Roland Singer [roland.singer@desertbit.com]
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package copy
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// CopyFile copies the contents of the file named src to the file named
+// by dst. The file will be created if it does not already exist. If the
+// destination file exists, all it's contents will be replaced by the contents
+// of the source file. The file mode will be copied from the source and
+// the copied data is synced/flushed to stable storage.
+func CopyFile(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return
+	}
+	defer func() {
+		if e := out.Close(); e != nil {
+			err = e
+		}
+	}()
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return
+	}
+
+	err = out.Sync()
+	if err != nil {
+		return
+	}
+
+	si, err := os.Stat(src)
+	if err != nil {
+		return
+	}
+	err = os.Chmod(dst, si.Mode())
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CopyDir recursively copies a directory tree, attempting to preserve permissions.
+// Source directory must exist, destination directory must *not* exist.
+// Symlinks are ignored and skipped.
+func CopyDir(src string, dst string) (err error) {
+	src = filepath.Clean(src)
+	dst = filepath.Clean(dst)
+
+	si, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !si.IsDir() {
+		return fmt.Errorf("source is not a directory")
+	}
+
+	_, err = os.Stat(dst)
+	if err != nil && !os.IsNotExist(err) {
+		return
+	}
+	if err == nil {
+		return fmt.Errorf("destination already exists")
+	}
+
+	err = os.MkdirAll(dst, si.Mode())
+	if err != nil {
+		return
+	}
+
+	entries, err := ioutil.ReadDir(src)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if entry.IsDir() {
+			err = CopyDir(srcPath, dstPath)
+			if err != nil {
+				return
+			}
+		} else {
+			// Skip symlinks.
+			if entry.Mode()&os.ModeSymlink != 0 {
+				continue
+			}
+
+			err = CopyFile(srcPath, dstPath)
+			if err != nil {
+				return
+			}
+		}
+	}
+
+	return
+}

--- a/show/show.go
+++ b/show/show.go
@@ -1,0 +1,81 @@
+/*
+Package show implements types and interfaces for moving shows
+*/
+package show
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/martinohansen/moverr/internal/copy"
+)
+
+// Mover is the interface for things that move
+type Mover interface {
+	Source() string
+	Movable() (bool, error)
+}
+
+// Show is a folder with a title and X number of media files
+type Show struct {
+	Directory, Title string
+	Media
+}
+
+// Media is one or more file paths
+type Media []struct {
+	File string
+}
+
+func (s Show) String() string {
+	return fmt.Sprintf("%s", s.Title)
+}
+
+// Source returns the source for a show
+func (s Show) Source() string {
+	return s.Directory
+}
+
+// Movable returns true if the show is alright to move
+func (s Show) Movable() (bool, error) {
+	locations := []string{s.Directory}
+
+	for _, location := range locations {
+		fi, err := os.Lstat(location)
+		if err != nil {
+			return false, err
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// Move a show and symbolic links the from source to destination
+func Move(m Mover, dst, sym string) error {
+	movable, err := m.Movable()
+	if movable {
+		src := path.Clean(m.Source())
+		dir, _ := path.Split(src)
+		dst = path.Join(path.Clean(dst), dir)
+		sym = path.Join(path.Clean(sym), dir)
+
+		err := copy.CopyDir(src, dst)
+		if err != nil {
+			os.RemoveAll(dst)
+			return fmt.Errorf("failed to copy: %s", err)
+		}
+		err = os.RemoveAll(src)
+		if err != nil {
+			return fmt.Errorf("failed to remove: %s", err)
+		}
+		err = os.Symlink(sym, src)
+		if err != nil {
+			return fmt.Errorf("failed to create symlink: %s", err)
+		}
+		return nil
+	}
+	return fmt.Errorf("show not movable: %s", err)
+}

--- a/show/show_test.go
+++ b/show/show_test.go
@@ -1,0 +1,51 @@
+package show
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+var testRoot string = "/tmp/moverr"
+var testSrc string = fmt.Sprintf("%s/src", testRoot)
+var testDst string = fmt.Sprintf("%s/dst", testRoot)
+var showPath string = fmt.Sprintf("%s/movie", testSrc)
+var showFile string = fmt.Sprintf("%s/movie.mp4", showPath)
+
+func initShow(t *testing.T) {
+	os.MkdirAll(showPath, 0755)
+	os.MkdirAll(testDst, 0755)
+	content := []byte("i'm a movie")
+	ioutil.WriteFile(showFile, content, 0755)
+}
+
+func cleanupShow(t *testing.T) {
+	err := os.RemoveAll(testRoot)
+	if err != nil {
+		t.Errorf("failed to cleanup files: %s", err)
+	}
+}
+
+func TestMove(t *testing.T) {
+	initShow(t)
+	defer cleanupShow(t)
+
+	show := Show{Directory: showPath}
+	oldShow, _ := ioutil.ReadFile(showFile)
+
+	err := Move(show, testDst, testDst)
+	if err != nil {
+		t.Errorf("failed to move show: %s", err)
+	}
+
+	newShow, err := ioutil.ReadFile(showFile)
+	if err != nil {
+		t.Errorf("failed to read movie after move: %s", err)
+	}
+
+	if bytes.Compare(oldShow, newShow) != 0 {
+		t.Errorf("move is not the same after move")
+	}
+}


### PR DESCRIPTION
Show implements types and interfaces for moving shows which allows for
reusing across content managers. A simple unit test is also added.

New copy function is pulled into the repo which hopefully works better.

Test all packages and run in all branches with GitHub CI.